### PR TITLE
Fix copy and paste bug in __libc_fini_array

### DIFF
--- a/libc/src/initfini.c
+++ b/libc/src/initfini.c
@@ -31,7 +31,7 @@ static void __libc_init_array() {
 static void __libc_fini_array() {
     ssize_t count, i;
 
-    count = __preinit_array_end - __preinit_array_start;
+    count = __fini_array_end - __fini_array_start;
     for (i = count - 1; i >= 0; i--)
         __fini_array_start[i]();
 


### PR DESCRIPTION
I don't think it would have ever been called, but correct unused code is better than incorrect unused code.